### PR TITLE
Env vars with dashes are not expanding in Jenkins jobs. Switching to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,10 +155,10 @@
 		</profile>
 		
 		<profile>
-			<id>sonar-build</id>
+			<id>sonar_build</id>
 			<activation>
 				<property>
-					<name>sonar-build</name>
+					<name>sonar_build</name>
 					<value>true</value>
 				</property>
 			</activation>


### PR DESCRIPTION
…underscore.