### PR TITLE
Changing to minor release number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>gov.usgs.cida</groupId>
 	<artifactId>sparrow-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<name>Sparrow DSS Parent Project</name>
 
 	<url>http://cida.usgs.gov/sparrow/</url>

--- a/sparrow-business-integration-tests/pom.xml
+++ b/sparrow-business-integration-tests/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>gov.usgs.cida</groupId>
     <artifactId>sparrow-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>sparrow-business-integration-tests</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>sparrow-business-integration-tests</name>
   <url>http://maven.apache.org</url>
 <!--  <properties>

--- a/sparrow-business/pom.xml
+++ b/sparrow-business/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>gov.usgs.cida</groupId>
     <artifactId>sparrow-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>sparrow-business</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>sparrow-business</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/sparrow-datatable/pom.xml
+++ b/sparrow-datatable/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>gov.usgs.cida</groupId>
     <artifactId>sparrow-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>sparrow-datatable</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>sparrow-datatable</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/sparrow-geoserver/pom.xml
+++ b/sparrow-geoserver/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<artifactId>sparrow-parent</artifactId>
 		<groupId>gov.usgs.cida</groupId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>gov.usgs.cida</groupId>
 	<artifactId>sparrow-geoserver</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<name>Sparrow Geoserver</name>

--- a/sparrow-jmeter/pom.xml
+++ b/sparrow-jmeter/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<artifactId>sparrow-parent</artifactId>
 		<groupId>gov.usgs.cida</groupId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>gov.usgs.cida</groupId>
 	<artifactId>sparrow-jmeter</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<name>Sparrow JMeter</name>

--- a/sparrow-liquibase/pom.xml
+++ b/sparrow-liquibase/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>sparrow-parent</artifactId>
 		<groupId>gov.usgs.cida</groupId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>gov.usgs.cida</groupId>
 	<artifactId>sparrow-liquibase</artifactId>

--- a/sparrow-service-utils/pom.xml
+++ b/sparrow-service-utils/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>gov.usgs.cida</groupId>
 		<artifactId>sparrow-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>gov.usgs.cida</groupId>
 	<artifactId>sparrow-service-utils</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<name>sparrow-service-utils</name>
 	<url>http://maven.apache.org</url>
 

--- a/sparrow-service/pom.xml
+++ b/sparrow-service/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 	<groupId>gov.usgs.cida</groupId>
 		<artifactId>sparrow-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sparrow-service</artifactId>
 	<packaging>war</packaging>
 	<name>sparrow-service</name>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<properties>
 		<netbeans.hint.deploy.server>Tomcat</netbeans.hint.deploy.server>

--- a/sparrow-shared-test/pom.xml
+++ b/sparrow-shared-test/pom.xml
@@ -4,10 +4,10 @@
 	<parent>
 		<groupId>gov.usgs.cida</groupId>
 		<artifactId>sparrow-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>sparrow-shared-test</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<name>sparrow-shared-test</name>
 	<url>http://maven.apache.org</url>
 	<properties> </properties>

--- a/sparrow-shared-ui/pom.xml
+++ b/sparrow-shared-ui/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>gov.usgs.cida</groupId>
     <artifactId>sparrow-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>sparrow-shared-ui</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>sparrow-shared-ui</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/sparrow-sld/pom.xml
+++ b/sparrow-sld/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.usgs.cida</groupId>
         <artifactId>sparrow-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>sparrow-sld</artifactId>
     <packaging>jar</packaging>

--- a/sparrow-validation/pom.xml
+++ b/sparrow-validation/pom.xml
@@ -4,10 +4,10 @@
 	<parent>
 		<groupId>gov.usgs.cida</groupId>
 		<artifactId>sparrow-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>sparrow-validation</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<name>sparrow-validation</name>
 	<url>http://maven.apache.org</url>
 	<properties> </properties>

--- a/sparrow-web-ui/pom.xml
+++ b/sparrow-web-ui/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>gov.usgs.cida</groupId>
 		<artifactId>sparrow-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>sparrow-web-ui</artifactId>
 	<packaging>war</packaging>
 	<name>sparrow-web-ui</name>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<description>SPARROW web mapping application</description>
 	
 	<properties>

--- a/sparrow-wps/pom.xml
+++ b/sparrow-wps/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<artifactId>sparrow-parent</artifactId>
 		<groupId>gov.usgs.cida</groupId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<groupId>gov.usgs.cida</groupId>
 	<artifactId>sparrow-wps</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Sparrow WPS</name>


### PR DESCRIPTION
Since there are a lot of changes in-flight, it makes more sense to consider this work as a part of a minor version release. The HTTPS hotfix work will start using the old 2.0.1-SNAPSHOT patch version.