### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,22 @@
 					<version>0.7.0.201403182114</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.10.3</version>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+							<configuration>
+								<additionalparam>-Xdoclint:none</additionalparam>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<groupId>net.sf.alchim</groupId>
 					<artifactId>yuicompressor-maven-plugin</artifactId>
 					<version>0.7.1</version>


### PR DESCRIPTION
This is for the build to work correctly on prod (to support the https updates) and should eliminate the java doc errors during build.