### PR TITLE
Switching to secure mapped url

### DIFF
--- a/sparrow-tilecache-seed/geoserver/requirements.txt
+++ b/sparrow-tilecache-seed/geoserver/requirements.txt
@@ -1,3 +1,3 @@
--e git+http://cida-eros-stash.er.usgs.gov:7990/stash/scm/gsc/py_geoserver_rest.git@0.3.9#egg=geoserver_rest_requests-dev
+-e git+https://internal.cida.usgs.gov/stash/scm/gsc/py_geoserver_rest.git@0.3.9#egg=geoserver_rest_requests-dev
 lxml==3.4.1
 requests==2.5.1


### PR DESCRIPTION
Pip's requests to this internal http url began failing last night. Today, when I curl the same url, I get a 302 redirect to an https url with a self-signed certificate. This could be causing pip to fail.

```
$ curl -v 'http://cida-eros-stash.er.usgs.gov:7990/stash/scm/gsc/py_geoserver_rest.git'
*   Trying 152.61.236.45...
* Connected to cida-eros-stash.er.usgs.gov (152.61.236.45) port 7990 (#0)
> GET /stash/scm/gsc/py_geoserver_rest.git HTTP/1.1
> Host: cida-eros-stash.er.usgs.gov:7990
> User-Agent: curl/7.42.1
> Accept: */*
> 
< HTTP/1.1 302 Found
< Server: Apache-Coyote/1.1
< Cache-Control: private
< Expires: Wed, 31 Dec 1969 18:00:00 CST
< Location: https://cida-eros-stash.er.usgs.gov:8443/stash/scm/gsc/py_geoserver_rest.git
< Content-Length: 0
< Date: Fri, 03 Feb 2017 19:33:13 GMT
< 
```